### PR TITLE
Actually use PAM Service Name if set

### DIFF
--- a/internal/data/config.go
+++ b/internal/data/config.go
@@ -93,7 +93,7 @@ func getInt(key string) (ret int, err error) {
 
 func GetPAM() (details PAM, err error) {
 
-	response, err := etcd.Get(context.Background(), OidcDetailsKey)
+	response, err := etcd.Get(context.Background(), PamDetailsKey)
 	if err != nil {
 		return PAM{}, err
 	}


### PR DESCRIPTION
Get PAMDetailsKey instead of OidcDetailsKey from etcd in GetPAM function. This was likely a copy and paste error, preventing the use of a custom PAM service name (the default `/etc/pam.d/login` was used instead).