### PR TITLE
OIDC Scopes Configuration Feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,7 +345,9 @@ Full config example
             "IssuerURL": "http://localhost:8080/",
             "ClientSecret": "<OMITTED>",
             "ClientID": "account",
-            "GroupsClaimName": "groups"
+            "GroupsClaimName": "groups",
+            "DeviceUsernameClaim": "",
+            "Scopes": []
         }
     },
     "Clustering": {

--- a/docker-test-config.json
+++ b/docker-test-config.json
@@ -36,7 +36,9 @@
         "OIDC": {
             "IssuerURL": "",
             "ClientSecret": "",
-            "ClientID": ""
+            "ClientID": "",
+            "DeviceUsernameClaim": "",
+            "Scopes": []
         },
         "PAM": {
             "ServiceName": ""

--- a/example_config.json
+++ b/example_config.json
@@ -31,7 +31,9 @@
             "IssuerURL": "http://localhost:8080/",
             "ClientSecret": "AN EXAMPLE KEY",
             "ClientID": "account",
-            "GroupsClaimName": "groups"
+            "GroupsClaimName": "groups",
+            "DeviceUsernameClaim": "",
+            "Scopes": []
         },
         "PAM": {
             "ServiceName": "vpncheckpass"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -102,6 +102,8 @@ type Config struct {
 			ClientSecret    string
 			ClientID        string
 			GroupsClaimName string `json:",omitempty"`
+			DeviceUsernameClaim string `json:",omitempty"`
+			Scopes          []string `json:"scopes,omitempty"`
 		} `json:",omitempty"`
 
 		PAM struct {

--- a/internal/data/config.go
+++ b/internal/data/config.go
@@ -17,7 +17,8 @@ type OIDC struct {
 	ClientSecret        string
 	ClientID            string
 	GroupsClaimName     string
-	DeviceUsernameClaim string
+	DeviceUsernameClaim string `json:",omitempty"`
+	Scopes              []string `json:"scopes,omitempty"`
 }
 
 type PAM struct {

--- a/internal/webserver/authenticators/oidc.go
+++ b/internal/webserver/authenticators/oidc.go
@@ -75,7 +75,11 @@ func (o *Oidc) Init() error {
 	log.Println("OIDC callback: ", u.String())
 	log.Println("Connecting to OIDC provider: ", o.details.IssuerURL)
 
-	o.provider, err = rp.NewRelyingPartyOIDC(o.details.IssuerURL, o.details.ClientID, o.details.ClientSecret, u.String(), []string{"openid"}, options...)
+    if len(o.details.Scopes) == 0 {
+        o.details.Scopes = []string{"openid"}
+    }
+
+	o.provider, err = rp.NewRelyingPartyOIDC(o.details.IssuerURL, o.details.ClientID, o.details.ClientSecret, u.String(), o.details.Scopes, options...)
 	if err != nil {
 		return err
 	}

--- a/ui/src/js/settings.js
+++ b/ui/src/js/settings.js
@@ -67,6 +67,7 @@ $(function () {
                 "ClientID": $('#oidcClientID').val(),
                 "GroupsClaimName": $('#oidcGroupsClaimName').val(),
                 "DeviceUsernameClaim": $("#oidcDeviceUsernameClaim").val(),
+                "Scopes": $('#oidcScopes').val().split("\n").filter(element => element),
             },
             "PamDetails": {
                 "ServiceName": $('#pamServiceName').val(),

--- a/ui/templates/settings/general.html
+++ b/ui/templates/settings/general.html
@@ -153,6 +153,11 @@
                             name="oidcDeviceUsernameClaim" value="{{.Settings.OidcDetails.DeviceUsernameClaim}}"
                             placeholder="(optional)">
                     </div>
+                    <div class="form-group mb-3">
+                        <label for="oidcScopes">Scopes (New line delimited)</label>
+                        <textarea class="form-control" id="oidcScopes" name="oidcScopes" rows="3">{{- range $index, $scope := .Settings.OidcDetails.Scopes -}}{{- if $index -}}{{"\n"}}{{- end -}}{{$scope}}{{- end -}}</textarea>
+                        <small>Default is 'openid'</small>
+                    </div>
 
                     <!-- PAM Settings -->
                     <div class="form-group">


### PR DESCRIPTION
### Description

This PR introduces two new configurable options for OIDC authentication in WireGuard Wag:

  1. Configurable OIDC Scopes

      - Previously, the openid scope was hardcoded in the OIDC requests.
      - With this PR, the scopes are now configurable both via the configuration file and the dashboard.
      - The default value remains openid, ensuring backward compatibility.
      - **Reason**: Some external identity providers (IdPs) such as Dex, GitHub, etc., require additional scopes to be explicitly present in the authentication request for successful authorization. Hardcoding the openid scope limits flexibility and can cause issues when integrating with such IdPs. Making scopes configurable allows users to adapt the OIDC integration based on their specific IdP’s requirements.

  2. Configurable OIDC Device Username Claim

      - This PR also adds support for configuring the username claim used in the OIDC Device Flow.
      - Users can now specify the desired username claim through the configuration file or the dashboard (e.g., preferred_username, email, etc.).
      - This makes it easier to customize how usernames are mapped from the OIDC token, accommodating different IdPs’ naming conventions.

----
### Changes Made

  - Added `Authenticators.OIDC.Scopes` to the configuration file and dashboard.
  - Added `Authenticators.OIDC.DeviceUsernameClaim` to the configuration file.
  - Updated OIDC authentication logic to use the configured scopes.
  - Ensured backward compatibility by setting default values (openid for scopes and username for username claim).
 
----
### How to Configure

Example Configuration File (config.json) Changes:
```json
...
    "Authenticators": {
       . . .
        ],
        "OIDC": {
            "IssuerURL": "http://localhost:8080/",
            "ClientSecret": "AN EXAMPLE KEY",
            "ClientID": "account",
            "GroupsClaimName": "groups",
            "DeviceUsernameClaim": "preferred_username",
            "Scopes": ["openid", "profile", "email"]
...
```

Dashboard Changes:

In the Settings Login section of the Wag dashboard, users can now:

  - Edit the OIDC Scopes field.