### PR TITLE
MFA portal frontend PAM auth fix

### DIFF
--- a/internal/mfaportal/resources/frontend/src/router/index.ts
+++ b/internal/mfaportal/resources/frontend/src/router/index.ts
@@ -28,9 +28,9 @@ const router = createRouter({
       name: "pam_register",
       component: () => import("../pages/registration/Pam.vue"),
     },    {
-      path: "/register/pam",
-      name: "pam_register",
-      component: () => import("../pages/registration/Pam.vue"),
+      path: "/authorise/pam",
+      name: "pam_authorise",
+      component: () => import("../pages/authorisation/Pam.vue"),
     },
     {
       path: "/register/webauthn",


### PR DESCRIPTION
There is a copy-paste error in the MFA portal frontend code. It makes the authorise action using the UI impossible to use.