### PR TITLE
TASK: speed up Docker build by caching Golang

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,11 @@ RUN apt-get update && \
 
 WORKDIR /app
 COPY . .
-RUN make release
+RUN --mount=type=cache,target=/go/pkg/mod,sharing=locked \
+    --mount=type=cache,target=/root/.cache/go-build,sharing=locked \
+    GOMODCACHE=/go/pkg/mod \
+    GOCACHE=/root/.cache/go-build \
+    make release
 
 # hadolint ignore=DL3007
 FROM redhat/ubi9-minimal:latest


### PR DESCRIPTION
As described in [1], we can use cache mounts to
speed up the Golang build. This means we do not
download all go dependencies all the time, and
also keep intermediate compilation artifacts.

This has no downsides IMHO, because the Go compiler automatically detects if the artifacts are stale or not.

[1] https://docs.docker.com/build/cache/optimize/#use-cache-mounts