### PR TITLE
FEATURE: Exclude IP Ranges from NAT

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,8 @@ The web interface itself cannot add administrative users.
 `Socket`: Wag control socket, changing this will allow multiple wag instances to run on the same machine  
 `GID`: The group ID that the wag control socket (`/tmp/wag*`) should be set to  
 
-`NAT`: Turn on or off masquerading  
+`NAT`: Turn on or off masquerading. If enabled, all traffic appears as if it was originated from the VPN server.  
+`NATExcludeRanges`: (only relevant if `NAT=true`) - an array of CIDR ranges to exclude from NAT. For example, if you set this to `["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"]`, then NAT will only be applied to traffic flowing to the public internet, but not to private networks.
 `ExposePorts`: Expose ports on the VPN server to the client (adds rules to IPtables) example: [ "443/tcp", "100-200/udp" ]  
 `CheckUpdates`: If enabled (off by default) the management UI will show an alert if a new version of wag is available. This talks to `api.github.com`   
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -56,8 +56,9 @@ type Config struct {
 	NumberProxies int
 	DevMode       bool `json:",omitempty"`
 
-	ExposePorts []string `json:",omitempty"`
-	NAT         *bool    `json:",omitempty"`
+	ExposePorts      []string `json:",omitempty"`
+	NAT              *bool    `json:",omitempty"`
+	NATExcludeRanges []string `json:",omitempty"`
 
 	Webserver struct {
 		Acme struct {


### PR DESCRIPTION
Hey @NHAS ,

another small one :) 

If NAT is enabled (default), this looks as if all traffic originated from the VPN server. However, this is not practical if one wants to do access control based on VPN IPs.

So in my case, I want NAT to be disabled for internal traffic, and enabled for the "remaining" traffic going to the public internet.

Thus I added a config option `NATExcludeRanges` which does exactly this :-)

Feedback highly welcome! For me this change works in production.

All the best,
Sebastian